### PR TITLE
Fix version file URL property

### DIFF
--- a/ReleaseFolder/GameData/WildBlueIndustries/Buffalo2/Buffalo2.version
+++ b/ReleaseFolder/GameData/WildBlueIndustries/Buffalo2/Buffalo2.version
@@ -1,6 +1,6 @@
 {
     "NAME":"Buffalo2",
-    "URL":"https://raw.githubusercontent.com/Angel-125/Buffalo2/master/GameData/WildBlueIndustries/Buffalo2/Buffalo2.version",
+    "URL":"https://raw.githubusercontent.com/Angel-125/Buffalo2/main/ReleaseFolder/GameData/WildBlueIndustries/Buffalo2/Buffalo2.version",
     "DOWNLOAD":"https://github.com/Angel-125/Buffalo2/releases",
     "GITHUB":
     {


### PR DESCRIPTION
Hi @Angel-125!

The URL property of the version file is a 404 currently.

- This repo apparently uses a `main` branch instead of `master`
- `ReleaseFolder` missing from path

This pull request fixes it.

Noticed while reviewing KSP-CKAN/NetKAN#9310.