### PR TITLE
Fix B9PS fatal error

### DIFF
--- a/ReleaseFolder/GameData/WildBlueIndustries/Buffalo2/Patches/B9PSTankTypes.cfg
+++ b/ReleaseFolder/GameData/WildBlueIndustries/Buffalo2/Patches/B9PSTankTypes.cfg
@@ -1,5 +1,6 @@
-// Based on the tank types from Buff2
-B9_TANK_TYPE:NEEDS[B9PartSwitch,WBIResources]
+// If WBI Resources not installed, use B9PS for resource switching.
+// Define tank options.
+B9_TANK_TYPE:NEEDS[B9PartSwitch,!WBIResources]
 {
 	name = Buff2Ore
 	RESOURCE
@@ -9,7 +10,7 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2MetallicOre
 	RESOURCE
@@ -19,7 +20,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Uraninite
 	RESOURCE
@@ -29,7 +30,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Substrate
 	RESOURCE
@@ -39,7 +40,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Minerals
 	RESOURCE
@@ -49,7 +50,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Karbonite
 	RESOURCE
@@ -59,7 +60,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Commodities
 	RESOURCE
@@ -74,7 +75,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2MaterialKits
 	RESOURCE
@@ -84,7 +85,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Metals
 	RESOURCE
@@ -94,7 +95,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Polymers
 	RESOURCE
@@ -104,7 +105,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Supplies
 	RESOURCE
@@ -120,7 +121,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Machinery
 	RESOURCE
@@ -130,7 +131,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Recyclables
 	RESOURCE
@@ -140,7 +141,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2SpecializedParts
 	RESOURCE
@@ -150,7 +151,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Fertilizer
 	RESOURCE
@@ -160,7 +161,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Hydrates
 	RESOURCE
@@ -170,7 +171,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Gypsum
 	RESOURCE
@@ -180,7 +181,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Dirt
 	RESOURCE
@@ -190,7 +191,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Silicates
 	RESOURCE
@@ -200,7 +201,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Silicon
 	RESOURCE
@@ -210,7 +211,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2RefinedExotics
 	RESOURCE
@@ -220,7 +221,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2ColonySupplies
 	RESOURCE
@@ -230,7 +231,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Organics
 	RESOURCE
@@ -240,7 +241,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Rock
 	RESOURCE
@@ -250,7 +251,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2ExoticMinerals
 	RESOURCE
@@ -260,7 +261,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2RareMetals
 	RESOURCE
@@ -270,7 +271,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Water
 	RESOURCE
@@ -280,7 +281,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Lead
 	RESOURCE
@@ -290,7 +291,7 @@ B9_TANK_TYPE:NEEDS[CommunityResourcePack,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[Snacks,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[Snacks,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Snacks
 	RESOURCE
@@ -300,7 +301,7 @@ B9_TANK_TYPE:NEEDS[Snacks,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[Snacks,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[Snacks,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Soil
 	RESOURCE
@@ -310,7 +311,7 @@ B9_TANK_TYPE:NEEDS[Snacks,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[SnacksFreshAir,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[SnacksFreshAir,B9PartSwitch,!WBIResources]
 {
 	name = Buff2FreshAir
 	RESOURCE
@@ -320,7 +321,7 @@ B9_TANK_TYPE:NEEDS[SnacksFreshAir,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[SnacksFreshAir,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[SnacksFreshAir,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Air
 	RESOURCE
@@ -335,7 +336,7 @@ B9_TANK_TYPE:NEEDS[SnacksFreshAir,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[ExtraplanetaryLaunchpads,!MKS,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[ExtraplanetaryLaunchpads,!MKS,B9PartSwitch,!WBIResources]
 {
 	name = Buff2RocketParts
 	RESOURCE
@@ -345,7 +346,7 @@ B9_TANK_TYPE:NEEDS[ExtraplanetaryLaunchpads,!MKS,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[ExtraplanetaryLaunchpads,!MKS,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[ExtraplanetaryLaunchpads,!MKS,B9PartSwitch,!WBIResources]
 {
 	name = Buff2MetalOre
 	RESOURCE
@@ -355,7 +356,7 @@ B9_TANK_TYPE:NEEDS[ExtraplanetaryLaunchpads,!MKS,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[ExtraplanetaryLaunchpads,!SimpleConstruction,!MKS,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[ExtraplanetaryLaunchpads,!SimpleConstruction,!MKS,B9PartSwitch,!WBIResources]
 {
 	name = Buff2ScrapMetal
 	RESOURCE
@@ -365,7 +366,7 @@ B9_TANK_TYPE:NEEDS[ExtraplanetaryLaunchpads,!SimpleConstruction,!MKS,B9PartSwitc
 	}
 }
 
-B9_TANK_TYPE:NEEDS[ExtraplanetaryLaunchpads,!MKS,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[ExtraplanetaryLaunchpads,!MKS,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Metal
 	RESOURCE
@@ -375,7 +376,7 @@ B9_TANK_TYPE:NEEDS[ExtraplanetaryLaunchpads,!MKS,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[TacLifeSupport,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[TacLifeSupport,B9PartSwitch,!WBIResources]
 {
 	name = Buff2TAC
 	RESOURCE
@@ -413,7 +414,7 @@ B9_TANK_TYPE:NEEDS[TacLifeSupport,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[TacLifeSupport,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[TacLifeSupport,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Food
 	RESOURCE
@@ -423,7 +424,7 @@ B9_TANK_TYPE:NEEDS[TacLifeSupport,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[TacLifeSupport,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[TacLifeSupport,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Oxygen
 	RESOURCE
@@ -433,7 +434,7 @@ B9_TANK_TYPE:NEEDS[TacLifeSupport,B9PartSwitch,WBIResources]
 	}
 }
 
-B9_TANK_TYPE:NEEDS[DeepFreeze,B9PartSwitch,WBIResources]
+B9_TANK_TYPE:NEEDS[DeepFreeze,B9PartSwitch,!WBIResources]
 {
 	name = Buff2Glykerol
 	RESOURCE


### PR DESCRIPTION
Condition: If WBI Resources not installed, use B9PS.
Problem: If WBI Resources not installed, B9 tank types not defined.